### PR TITLE
bugfix DateTime

### DIFF
--- a/Kernys.Bson/SimpleBSON.cs
+++ b/Kernys.Bson/SimpleBSON.cs
@@ -463,7 +463,7 @@ namespace Kernys.Bson
 			} else if(elementType == 0x09) { // DateTime
 				name = decodeCString ();
 				Int64 time = mBinaryReader.ReadInt64 ();
-				return new BSONValue (new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc) + new TimeSpan(time));
+				return new BSONValue (new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc) + new TimeSpan(time*10000));
 			} else if(elementType == 0x0A) { // None
 				name = decodeCString ();
 				return new BSONValue ();
@@ -649,7 +649,13 @@ namespace Kernys.Bson
 			ms.Write (buf, 0, buf.Length);
 		}
 		private void encodeUTCDateTime(MemoryStream ms, DateTime dt) {
-			TimeSpan span = (dt - new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).ToLocalTime());
+			TimeSpan span;
+			if(dt.Kind == DateTimeKind.Local) {
+				span = (dt - new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).ToLocalTime());				
+			}
+			else {
+				span = dt - new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);				
+			}			
 			byte []buf = BitConverter.GetBytes ((Int64)(span.TotalSeconds * 1000));
 			ms.Write (buf, 0, buf.Length);
 		}


### PR DESCRIPTION
## Wrong TimeSpan Parameter

`new TimeSpan(time)`
From [msdn](http://msdn.microsoft.com/en-us/library/zz841zbz%28v=vs.110%29.aspx):

> TimeSpan(long ticks) :
> A single tick represents one hundred nanoseconds or one ten-millionth of a second. There are 10,000 ticks in a millisecond.
## Missing Check DateTime Kind

`encodeUTCDateTime(MemoryStream ms, DateTime dt)`
if dt's type is not local time, don't convert it to local time. 
